### PR TITLE
Reduce dependencies footprint (and therefore bundle size)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "mocha -r ts-node/register tests/**/*.test.ts"
   },
   "dependencies": {
-    "moment": "^2.22.2"
+    "date-fns": "^2.0.1"
   },
   "bugs": {
     "url": "https://github.com/eric-malachias/irr/issues"

--- a/src/irr/transform.ts
+++ b/src/irr/transform.ts
@@ -1,5 +1,24 @@
-import moment from 'moment'
+import differenceInDays from 'date-fns/differenceInDays'
 import { XirrInput, InternalXirrInput } from './definition'
+
+const dateFormat = /(\d{4})(\d{2})(\d{2})/
+
+/**
+ * @param input a date string formatted like yyyyMMdd
+ */
+function parseDate (input: string): Date {
+  const result = dateFormat.exec(input)
+  if (result === null) {
+    throw new Error('Date format error')
+  }
+
+  const [, year, month, day] = result
+  return new Date(
+    Number.parseInt(year),
+    Number.parseInt(month) - 1,
+    Number.parseInt(day)
+  )
+}
 
 export function transform (inputs: XirrInput[]): InternalXirrInput[] {
   if (inputs.length === 0) {
@@ -9,7 +28,10 @@ export function transform (inputs: XirrInput[]): InternalXirrInput[] {
   const { date } = inputs[0]
   const transformedInputs = inputs.map(input => ({
     amount: input.amount,
-    day: moment(input.date).diff(moment(date), 'days'),
+    day: differenceInDays(
+      parseDate(input.date),
+      parseDate(date)
+    )
   }))
   const firstDay = Math.min(...transformedInputs.map(({ day }) => day))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,6 +158,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+date-fns@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.1.tgz#c5f30e31d3294918e6b6a82753a4e719120e203d"
+  integrity sha512-C14oTzTZy8DH1Eq8N78owrCWvf3+cnJw88BTK/N3DYWVxDJuJzPaNdplzYxDYuuXXGvqBcO4Vy5SOrwAooXSWw==
+
 debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -315,10 +320,6 @@ mocha@^5.2.0:
     minimatch "3.0.4"
     mkdirp "0.5.1"
     supports-color "5.4.0"
-
-moment@^2.22.2:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi @eric-malachias

Thanks for your fantastic package. We realised it wasn't designed to be used in the browser but turns out it runs well there as well. We were considering using it in our web app but when bundling we discovered that _momentjs_ represents 98% of the gzipped size (about 64KB out of 65KB).

We tried to come up with a solution to drastically reduce the footprint while keeping the same feature set. We think it is a significant improvement (reducing the resulting bundle size to 2.19KB: 3% of the initial size). We would love to see this merged and release but ultimately it is up to you to decide 😀. Happy to make any change you would consider necessary.

WDYT?